### PR TITLE
Bump event-engine/php-engine dep to v0.16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": "^7.3 || ^8.0",
     "roave/security-advisories": "dev-master",
-    "event-engine/php-engine": "^0.15",
+    "event-engine/php-engine": "^0.16",
     "laminas/laminas-diactoros": "^2.2"
   },
   "autoload": {


### PR DESCRIPTION
Hey @codeliner. I'm not sure if you are aware of this. While I am grateful for the quick merges and releases with PHP 8 support (thanks again!) I wonder why most of them were released in a minor version. In the 0.x range, semver allow minor releases to break bc. Therefor creating a minor release behaves like a major release. This requires all the dependent packages to bump their dependency constraints just like with a major release.

Anyway, here's the required bump for this package 😃 